### PR TITLE
Fix the PersistentVolumeClaim storageClassName

### DIFF
--- a/testing_openstack_code_changes_with_operators.md
+++ b/testing_openstack_code_changes_with_operators.md
@@ -68,7 +68,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: neutron-code-dev
 spec:
-  storageClassName: neutron-code-dev
+  storageClassName: neutron-code
   accessModes:
     - ReadOnlyMany
   resources:
@@ -101,7 +101,7 @@ spec:
             volumes:
             - name: neutron-code
               persistentVolumeClaim:
-                claimName: neutron-code
+                claimName: neutron-code-dev
                 readOnly: true
           name: neutron-code
 ```


### PR DESCRIPTION
Both the PV and the PVC claiming a specific PV, should have the same ``storageClassName``.

This patch is also fixing the Neutron
``extraVol.volumes.persistentVolumeClaim.claimName``, matching the one assigned to the created PVC.