### PR TITLE
HCI nodesets must have complete services list post deploy

### DIFF
--- a/ceph.md
+++ b/ceph.md
@@ -329,13 +329,10 @@ spec:
     edpm-compute:
       ...
       services:
-        - configure-network
-        - validate-network
-        - install-os
-        - configure-os
-        - run-os
+        - install-certs
         - ceph-client
         - ovn
+        - neutron-metadata
         - libvirt
         - nova-custom-ceph
 ```


### PR DESCRIPTION
It was reported that edpm-update services skips container update tasks for custom services. However, we found this was because the services list for the HCI deployment where we teseted was missing the run-os service. This service was missing since the second deploy excluded it since HCI uses two deploys. That's fine, provided the full service list is restored at the end.

This change documents that you must recombine the service list and describes how to do it.