### PR TITLE
Update local operator/webhooks docs for new install paradigm

### DIFF
--- a/custom_openstack_operator.md
+++ b/custom_openstack_operator.md
@@ -84,8 +84,16 @@ Build the custom OpenStack operator (this will take a few minutes)
 
 Do not forget to login to your Quay account with `podman login` before running the command below.
 
+**FR1 and earlier**
+
 ```bash
 $ IMAGE_TAG_BASE=quay.io/andrewbays/openstack-operator VERSION=0.0.1 IMG=$IMAGE_TAG_BASE:v$VERSION make manifests build docker-build docker-push bundle bundle-build bundle-push catalog-build catalog-push
+```
+
+**FR2 and later**
+
+```bash
+$ IMAGE_TAG_BASE=quay.io/andrewbays/openstack-operator VERSION=0.0.1 IMG=$IMAGE_TAG_BASE:v$VERSION make manifests bindata build docker-build docker-push bundle bundle-build bundle-push catalog-build catalog-push
 ```
 
 Note: If your GitHub username is NOT the same as your Quay username add `IMAGENAMESPACE=<your Quay username>`
@@ -110,17 +118,25 @@ $ make openstack_cleanup
 2. Deploy your custom OpenStack operator that includes your custom service operator changes
 
 ```bash
-$ OPENSTACK_IMG=quay.io/andrewbays/openstack-operator-index:v0.0.1 make openstack
+$ OPENSTACK_IMG=quay.io/andrewbays/openstack-operator-index:v0.0.1 make openstack_wait
 ```
 
 Notice the URI format of the `OPENSTACK_IMG` variable: `quay.io/<your Quay username>/openstack-operator-index:v<your custom version tag>`.
 Use your Quay username and the version you specified via `VERSION` when you built your custom OpenStack operator.
 
-Within a few minutes, your custom OpenStack operator and custom service operators(s) will be available for use.
+### 5. Initialize OpenStack Operator (FR2 and later only)
 
-### 5. Create OpenStack Operator CRs
+Within a few minutes, your custom OpenStack operator will be ready for initialization.  Now that the OpenStack Operator is installed,
+it needs to be initialized to deploy all of the service operators.
 
-Now you can create an `OpenStackControlPlane` CR, for instance, and test the changes in your custom service operator.
+```bash
+make openstack_init
+```
+
+### 6. Create OpenStack Operator CRs
+
+Once all of the operators are installed, you can create an `OpenStackControlPlane` CR, for instance, and test the changes in
+your custom service operator.
 
 ```bash
 $ make openstack_deploy

--- a/running_local_operator.md
+++ b/running_local_operator.md
@@ -9,12 +9,22 @@ However, the operator deployed by the meta operator (from when you
 ran `make openstack`) will conflict with your local copy. E.g. both
 operators might try to resolve the same CR.
 
+**FR1 and earlier**
+
 To avoid the conflict, scale down the operator deployed by the meta
 operator by either setting its controller-manager pod replicas to 0
 or removing the deployment from the CSV entirely so that only your
 local operator will resolve its CR.
 
-## Disabling a service within the CSV
+**FR2 and later**
+
+To avoid the conflict, scale down the OpenStack operator CSV's deployment
+`replicas` to 0 and then scale down the associated service operator deployment
+`replicas` to 0 as well.
+
+## Disabling a service
+
+**FR1 and earlier**
 
 1. Backup the operator's CSV in case you want to restore it later:
 
@@ -45,7 +55,23 @@ oc patch csv -n openstack-operators <your operator CSV> --type json \
 oc patch csv -n openstack-operators <your operator CSV> --type=merge --patch-file=operator_csv.json
 ```
 
-## An Alternative Approach Provided by ChatGPT
+**FR2 and later**
+
+1. Drop the OpenStack operator's CSV's deployment `replicas` to 0
+
+```bash
+oc patch csv -n openstack-operators <OpenStack operator CSV> --type json \
+  -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "0"}]"
+```
+
+2. Drop the service operator's deployment `replicas` to 0
+
+```bash
+oc patch deployment -n openstack-operators <service operator deployment> --type json \
+  -p="[{"op": "replace", "path": "/spec/replicas", "value": "0"}]"
+```
+
+## An Alternative Approach Provided by ChatGPT (FR1 and earlier)
 
 In Kubernetes, CSV (Cluster Service Version) is a Custom Resource Definition (CRD) that enables the operator to manage the lifecycle of a specific application in a Kubernetes cluster. The CSV defines the deployment strategy, dependencies, and upgrade paths for the application.
 


### PR DESCRIPTION
Our developer documentation for running local operators and/or webhooks needs to be updated in light of the new install paradigm [1].  There are certain limitations that are now encountered that currently restrict the options for local deployments.

[1] https://dprince.github.io/openstack-operator-initialization-resource.html  